### PR TITLE
Translatable marker name and popup content - Marker.php

### DIFF
--- a/models/Marker.php
+++ b/models/Marker.php
@@ -30,6 +30,16 @@ class Marker extends Model implements AddressObjectInterface
         'lat' => 'required|numeric',
         'lon' => 'required|numeric'
     ];
+    
+    /**
+    * @var translatable marker fields
+    */
+    public $implement = ['@RainLab.Translate.Behaviors.TranslatableModel'];
+    
+    public $translatable = [
+        'name',
+        'popup_content'
+    ];
 
     /**
      * @var array Guarded fields


### PR DESCRIPTION
Hey team. I don't mind extending the plugin in my projects but it might be a nice idea to make at least the marker name and popup content conditionally translatable by default.